### PR TITLE
Updates ion-c to latest.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.idea
+/target

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "cmake",
+ "libc",
 ]
 
 [[package]]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use cmake::Config;
+use std::env;
 use std::fs::create_dir_all;
 use std::path::Path;
 use std::process;
@@ -37,11 +38,21 @@ fn main() {
 
     // decNumber library
     println!("cargo:rustc-link-search=native=./ion-c/build/release/build/decNumber");
-    println!("cargo:rustc-link-lib=static=decNumberStatic");
+    println!("cargo:rustc-link-lib=static=decNumber_static");
 
     // C++ library
-    println!("cargo:rustc-link-search=native=/usr/lib");
-    println!("cargo:rustc-link-lib=c++");
+    let target = env::var("TARGET").unwrap();
+    if target.contains("apple") {
+        // macOS users use libc++
+        println!("cargo:rustc-link-lib=dylib=c++");
+    } else if target.contains("linux") {
+        // GCC users
+        println!("cargo:rustc-link-lib=dylib=stdc++");
+    } else {
+        // TODO support Windows/Unixes/etc. correctly
+        unimplemented!("Linking C++ is not yet supported on this platform {}", target);
+    }
+
 
     // ion-c CLI library
     println!("cargo:rustc-link-search=native=./ion-c/build/release/build/tools/cli/");


### PR DESCRIPTION
* Updates `build.rs`:
  - Changes `decNumberStatic` to `decNumber_static` because of changes
    to upstream.
  - Links against `libc++` on macOS and `libstdc++` on Linux.
  - Makes C++ linkage explicitly dynamic.
  - Adds TODO/explicit build failure for Windows and other platform.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
