### PR TITLE
ion-c now builds inside $OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,12 +5,18 @@ use std::path::Path;
 use std::process;
 
 fn main() {
-    let build_dir = Path::new("./ion-c/build/release");
+    // Cargo requires that build scripts only modify the contents of the folder $OUT_DIR.
+    // Here we construct a directory inside $OUT_DIR to store the output of the ion-c build process.
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let ion_c_release_dir = format!("{}/ion-c/build/release", &out_dir);
+    let ion_c_release_dir = ion_c_release_dir.as_str();
+    let ion_c_release_path = Path::new(ion_c_release_dir);
+    println!("ion-c build directory: {}", ion_c_release_dir);
 
     // Create the ion-c build directory if necessary
-    if !build_dir.is_dir() {
-        println!("Creating build directory {}", build_dir.display());
-        if let Err(error) = create_dir_all(build_dir) {
+    if !ion_c_release_path.is_dir() {
+        println!("Creating build directory {}", ion_c_release_dir);
+        if let Err(error) = create_dir_all(ion_c_release_path) {
             eprintln!("Could not create build directory: {:?}", error);
             process::exit(1);
         }
@@ -19,7 +25,7 @@ fn main() {
     // Configure and run CMake
     Config::new("ion-c")
         .define("CMAKE_BUILD_TYPE", "Release")
-        .out_dir("./ion-c/build/release")
+        .out_dir(&ion_c_release_path)
         .build();
 
     // Output lines that start with "cargo:" are interpreted by Cargo. See the docs for details:
@@ -29,15 +35,15 @@ fn main() {
     // which libraries to link against and in which directories they can be found.
 
     // ion_events library
-    println!("cargo:rustc-link-search=native=./ion-c/build/release/build/tools/events");
+    println!("cargo:rustc-link-search=native={}/build/tools/events", ion_c_release_dir);
     println!("cargo:rustc-link-lib=static=ion_events_static");
 
     // ion_c library
-    println!("cargo:rustc-link-search=native=./ion-c/build/release/build/ionc");
+    println!("cargo:rustc-link-search=native={}/build/ionc", ion_c_release_dir);
     println!("cargo:rustc-link-lib=static=ionc_static");
 
     // decNumber library
-    println!("cargo:rustc-link-search=native=./ion-c/build/release/build/decNumber");
+    println!("cargo:rustc-link-search=native={}/build/decNumber", ion_c_release_dir);
     println!("cargo:rustc-link-lib=static=decNumber_static");
 
     // C++ library
@@ -57,11 +63,11 @@ fn main() {
     }
 
     // ion-c CLI library
-    println!("cargo:rustc-link-search=native=./ion-c/build/release/build/tools/cli/");
+    println!("cargo:rustc-link-search=native={}/build/tools/cli/", ion_c_release_dir);
     println!("cargo:rustc-link-lib=static=ion_cli_main");
 
     // Only rebuild ion-c if that submodule directory is updated
-    println!("cargo:rereun-if-changed={}", build_dir.display());
+    println!("cargo:rerun-if-changed=./ion-c");
     // ...or if this build script is changed.
-    println!("cargo:rereun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build.rs");
 }


### PR DESCRIPTION
Cargo requires that build scripts [only modify the contents of the $OUT_DIR folder](https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script), a path which is passed in as an environment variable.

Previously, the build script (`build.rs`) would create a new folder in the ion-c submodule and store its build artifacts there. This caused Cargo to object when it tried to package the crate for publishing.

*Description of changes:*

This PR modifies the build script to create `$OUT_DIR/ion-c/build/release` instead of `./ion-c/build/release` and stores all build artifacts there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
