### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+/target
+/.idea
+
+*.md
+
+Dockerfile
+LICENSE
+NOTICE

--- a/.github/workflows/verify-docker-build.yml
+++ b/.github/workflows/verify-docker-build.yml
@@ -1,0 +1,26 @@
+name: Verify Docker image builds
+on:
+    push:
+        branches:
+            - master
+
+    pull_request:
+        branches:
+            - master
+
+jobs:
+  push_to_registry:
+    name: Build docker image
+    runs-on: ubuntu-20.04
+    steps:
+    -
+        name: Checkout repository
+        uses: actions/checkout@v2
+    -
+        name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v1
+    -
+        name: Build image
+        run: docker buildx build -t ion-cli:test-build .
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM rust:1.56-slim as builder
+ENV builddeps="cmake git gcc g++ clang"
+WORKDIR /usr/src/ion-cli
+COPY . .
+RUN apt-get update -y \
+  && apt-get install -y ${builddeps} \
+  && git submodule update --init --recursive
+RUN cargo install --path .
+
+FROM debian:11.1-slim
+COPY --from=builder /usr/local/cargo/bin/ion /usr/bin/ion
+CMD /usr/bin/ion
+VOLUME /data

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.56-slim as builder
-ENV builddeps="cmake git gcc g++ clang"
+ENV builddeps="cmake git clang"
 WORKDIR /usr/src/ion-cli
 COPY . .
 RUN apt-get update -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.56.1-slim-buster as builder
-ENV builddeps="cmake git clang"
+ENV builddeps="cmake git"
 WORKDIR /usr/src/ion-cli
 COPY . .
 RUN apt-get update -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.56-slim as builder
+FROM rust:1.56.1-slim-buster as builder
 ENV builddeps="cmake git clang"
 WORKDIR /usr/src/ion-cli
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.56.1-slim-buster as builder
-ENV builddeps="cmake git"
+ENV builddeps="cmake git clang"
 WORKDIR /usr/src/ion-cli
 COPY . .
 RUN apt-get update -y \

--- a/README.md
+++ b/README.md
@@ -33,6 +33,39 @@ and the API is subject to change._
    ion help
    ```
 
+### Docker Instructions
+
+1. Clone the repository (recursive clone not necessary)
+   ```
+   git clone https://github.com/amzn/ion-cli.git
+   ```
+2. Step into the newly created directory
+   ```
+   cd ion-cli
+   ```
+3. Install Docker (see OS specific instructions on the [Docker website](https://docs.docker.com/get-docker/))
+4. Build and run the image
+   ```
+   # build the image
+   docker build -t <IMAGE_NAME>:<TAG> .
+
+
+   # run the CLI binary inside the Docker image
+   docker run -it --rm [optional flags...] <IMAGE_NAME>:<TAG> ion <SUBCOMMAND>
+
+   # examples:
+
+   # build docker image with current release version
+   docker build -t ion-cli:0.1.1 .
+
+   # print the help message
+   docker run -it --rm ion-cli:0.1.1 ion -V
+
+   # mount current directory to /data volume and dump an ion file
+   docker run -it --rm -v $PWD:/data ion-cli:0.1.1 ion dump /data/test.ion
+
+   ```
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and the API is subject to change._
    ```
    This will put a copy of the `ion` executable in `~/.cargo/bin`.
 
-   **If this step fails:** You're likely missing one of `ion-c`'s dependencies. Make sure you have `cmake` and `clang` installed.
+   **If this step fails:** You're likely missing one of `ion-c`'s dependencies. Make sure you have `cmake`, `gcc`, `g++` and `clang` installed. On Debian-based Linux distributions, the only required dependencies are `cmake` and `clang`.
 
 5. Confirm that `~/.cargo/bin` is on your `$PATH`. `rustup` will probably take care of this for you.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ and the API is subject to change._
    ```
    This will put a copy of the `ion` executable in `~/.cargo/bin`.
 
-   **If this step fails:** You're likely missing one of `ion-c`'s dependencies. Make sure you have `cmake`, `gcc`, `g++`, and `libc++` installed.
+   **If this step fails:** You're likely missing one of `ion-c`'s dependencies. Make sure you have `cmake` and `clang` installed.
 
 5. Confirm that `~/.cargo/bin` is on your `$PATH`. `rustup` will probably take care of this for you.
 
@@ -35,15 +35,15 @@ and the API is subject to change._
 
 ### Docker Instructions
 
-1. Clone the repository (recursive clone not necessary)
+1. Install Docker (see OS specific instructions on the [Docker website](https://docs.docker.com/get-docker/))
+2. Clone the repository (recursive clone not necessary)
    ```
    git clone https://github.com/amzn/ion-cli.git
    ```
-2. Step into the newly created directory
+3. Step into the newly created directory
    ```
    cd ion-cli
    ```
-3. Install Docker (see OS specific instructions on the [Docker website](https://docs.docker.com/get-docker/))
 4. Build and run the image
    ```
    # build the image


### PR DESCRIPTION
Hi there!

I've added a Dockerfile that makes a *relatively small* multi-stage image of the CLI that should be usable cross-platform (only tested on macOS so far but no reason to believe it would fail on Windows/Linux).

I'm interested in contributing something more meaningful (i.e. tests for #10 when I have a little more time) but wanted to send this for now. I also understand if you don't want to merge since it *does* sadly change your repo stats from  100% to 99.1% Rust, 0.9% Dockerfile :smile:.

Question for maintainers:
- This builds and appears to run with latest release of Rust as of 10/22, version 1.56. Should this be pinned to another Rust version?
- I haven't looked too closely into [amzn/ion-c](https://github.com/amzn/ion-c) CMake files but the only C/C++ build dependencies on Debian appeared to be `cmake` and `clang`. Should I update the README to reflect this or Dockerfile be sufficient?

Thanks!


*Issue #, if available:*

N/A

*Description of changes:*

* Added Dockerfile to build minimal, multi-stage image
* Updated README with build instructions

Recording of local build/test:

[![asciicast](https://asciinema.org/a/Ql7Xc5fgxxvkFrjjcuMbR0npY.svg)](https://asciinema.org/a/Ql7Xc5fgxxvkFrjjcuMbR0npY)

Currently builds image size 85.8MB from local build on macOS

```
docker images
REPOSITORY                               TAG               IMAGE ID       CREATED          SIZE
ion-cli                                  0.1.1             e81a9d863b95   49 minutes ago   85.8MB
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
