### PR TITLE
Set edition to 2021 and bump to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,7 +300,7 @@ dependencies = [
 
 [[package]]
 name = "ion-cli"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "ion-cli"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["The Ion Team <ion-team@amazon.com>"]
-edition = "2018"
+edition = "2021"
 description = "Command line tool for working with the Ion data format."
 repository = "https://github.com/amzn/ion-cli"
 license = "Apache-2.0"


### PR DESCRIPTION
* Upgrades the crate to edition 2021
* Bumps the version from v0.1.1 to v0.2.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
