### PR TITLE
Fixes unreachable! calls in Rust 1.59+

### DIFF
--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -39,7 +39,7 @@ pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
             "The requested beta command ('{}') is not supported and clap did not generate an error message.",
             command_name
         );
-        unreachable!(message);
+        unreachable!("{}", message);
     }
     Ok(())
 }

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -35,7 +35,7 @@ pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
             "The requested schema command ('{}') is not supported and clap did not generate an error message.",
             command_name
         );
-        unreachable!(message);
+        unreachable!("{}", message);
     }
     Ok(())
 }

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
             "The requested command ('{}') is not supported and clap did not generate an error message.",
             command_name
         );
-        unreachable!(message);
+        unreachable!("{}", message);
     }
     Ok(())
 }


### PR DESCRIPTION
Starting in Rust 1.59, calls to the `unreachable!` macro no longer
accept string variables as their first parameter. This brings their
behavior in line with macros like `println!`, `format!`, and `write!`.

See: https://github.com/rust-lang/rust/issues/94475

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
