### PR TITLE
adds changes for validate subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "ion-schema"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338e16fcad39203a34e529cfb7da57df3e04c37dfc9bdb831399ed3bcd1bb865"
+checksum = "18a3ab276f000b1bb25a6f6c866c3d6d035fd76a3058dd789e7c2f370f70d27b"
 dependencies = [
  "chrono",
  "ion-rs 0.7.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ ion-rs = "0.8.0"
 libc = "0.2"
 memmap = "0.7.0"
 tempfile = "3.2.0"
-ion-schema = "0.1.0"
+ion-schema = "0.2.0"
 
 [build-dependencies]
 cmake = "0.1.44"

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -1,4 +1,5 @@
 pub mod load;
+pub mod validate;
 
 use anyhow::Result;
 use clap::{App, ArgMatches};
@@ -11,12 +12,14 @@ use crate::commands::{CommandRunner, CommandConfig};
 pub fn schema_subcommands() -> Vec<CommandConfig> {
     vec![
         load::app(),
+        validate::app()
     ]
 }
 
 pub fn runner_for_schema_subcommand(command_name: &str) -> Option<CommandRunner> {
     let runner = match command_name {
         "load" => load::run,
+        "validate" => validate::run,
         _ => return None
     };
     Some(runner)

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -1,0 +1,142 @@
+
+use anyhow::{Result};
+use clap::{App, Arg, ArgMatches};
+use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
+use std::path::Path;
+use ion_schema::system::SchemaSystem;
+use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
+use std::fs;
+use ion_schema::external::ion_rs::value::owned::OwnedElement;
+use ion_schema::external::ion_rs::text::writer::TextWriter;
+use ion_schema::external::ion_rs::IonType;
+use ion_schema::external::ion_rs::value::writer::{TextKind, Format, ElementWriter};
+use std::str::from_utf8;
+
+const ABOUT: &str = "validates an Ion Value based on given Ion Schema Type";
+
+// Creates a `clap` (Command Line Arguments Parser) configuration for the `load` command.
+// This function is invoked by the `load` command's parent `schema`, so it can describe its
+// child commands.
+pub fn app() -> App<'static, 'static> {
+    App::new("validate")
+        .about(ABOUT)
+        .arg(
+            // Schema file can be specified by the "-s" or "--schema" flags.
+            Arg::with_name("schema")
+                .long("schema")
+                .short("s")
+                .required(true)
+                .takes_value(true)
+                .value_name("SCHEMA")
+                .help("The Ion Schema file to load"),
+        )
+        .arg(
+            // Directory(s) that will be used as authority(s) for schema system
+            Arg::with_name("directories")
+                .long("directory")
+                .short("d")
+                .min_values(1)
+                .takes_value(true)
+                .multiple(true)
+                .value_name("DIRECTORY")
+                .required(true)
+                .help("One or more directories that will be searched for the requested schema"),
+        )
+        .arg(
+            // Input ion file can be specified by the "-i" or "--input" flags.
+            Arg::with_name("input")
+                .long("input")
+                .short("i")
+                .required(true)
+                .takes_value(true)
+                .value_name("INPUT_FILE")
+                .help("Input file containing the Ion values to be validated"),
+        )
+        .arg(
+            // Schema Type can be specified by the "-t" or "--type" flags.
+            Arg::with_name("type")
+                .long("type")
+                .short("t")
+                .required(true)
+                .takes_value(true)
+                .value_name("TYPE")
+                .help("Name of schema type from given schema that needs to be used for validation"),
+        )
+}
+
+// This function is invoked by the `load` command's parent `schema`.
+pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
+    // Extract the user provided document authorities/ directories
+    let authorities: Vec<_> = matches.values_of("directories").unwrap().collect();
+
+    // Extract schema file provided by user
+    let schema_id = matches.value_of("schema").unwrap();
+
+    // Extract the schema type provided by user
+    let schema_type = matches.value_of("type").unwrap();
+
+    // Extract Ion value provided by user
+    let input_file = matches.value_of("input").unwrap();
+    let value = fs::read(input_file).expect("Can not load given ion file");
+    let owned_elements: Vec<OwnedElement> = element_reader()
+        .read_all(&value)
+        .expect("parsing failed unexpectedly");
+
+    // Set up document authorities vector
+    let mut document_authorities: Vec<Box<dyn DocumentAuthority>> = vec![];
+
+    for authority in authorities {
+        document_authorities.push(Box::new(FileSystemDocumentAuthority::new(Path::new(
+            authority,
+        ))))
+    }
+
+    // Create a new schema system from given document authorities
+    let mut schema_system = SchemaSystem::new(document_authorities);
+
+    // load schema
+    let schema = schema_system.load_schema(schema_id);
+
+    // get the type provided by user from the schema file
+    let type_ref = schema.unwrap().get_type(schema_type).unwrap();
+
+    // create a text writer to make the output
+    let mut output = vec![];
+    let mut writer = TextWriter::new(&mut output);
+
+    // validate owned_elements according to type_ref
+    for owned_element in owned_elements {
+        // create a validation report with validation result, value, schema and/or violation
+        writer.step_in(IonType::Struct)?;
+        let validation_result = type_ref.validate(&owned_element);
+        writer.set_field_name("result");
+        match validation_result {
+            Ok(_) => {
+                writer.write_string("Valid")?;
+                writer.set_field_name("value");
+                const TEST_BUF_LEN: usize = 4 * 1024 * 1024;
+                let mut buf = vec![0u8; TEST_BUF_LEN];
+                let mut element_writer =
+                    Format::Text(TextKind::Pretty).element_writer_for_slice(&mut buf)?;
+                element_writer.write(&owned_element)?;
+                let slice = element_writer.finish()?;
+                let slice = from_utf8(slice).unwrap_or("<INVALID UTF-8>");
+                writer.write_string(slice)?;
+                writer.set_field_name("schema");
+                writer.write_string(schema_id)?;
+            }
+            Err(_) => {
+                writer.write_string("Invalid")?;
+                writer.set_field_name("violation");
+                writer.write_string(format!("{:#?}", validation_result.unwrap_err()))?;
+            }
+        }
+        writer.step_out()?;
+    }
+    drop(writer);
+    println!("Validation report:");
+    println!("{}", from_utf8(&output).unwrap());
+    Ok(())
+}
+
+


### PR DESCRIPTION
*Description of changes:*
This PR adds `validate` sub command to `schema`.

*Validate:*
```
ion-beta-schema-validate 
validates an Ion Value based on given Ion Schema Type

USAGE:
    ion beta schema validate --directory <DIRECTORY>... --input <INPUT_FILE> --schema <SCHEMA> --type <TYPE>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -d, --directory <DIRECTORY>...    One or more directories that will be searched for the requested schema
    -i, --input <INPUT_FILE>          Input file containing the Ion values to be validated
    -s, --schema <SCHEMA>             The Ion Schema file to load
    -t, --type <TYPE>                 Name of schema type from given schema that needs to be used for validation

```