### PR TITLE
Add Windows build again, remove LLVM, Clang CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,7 @@ jobs:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != 'amzn/ion-cli'
     strategy:
       matrix:
-        # TODO: add windows after fixing cmake version error issues
-        # see for example Windows build workflow: https://github.com/amzn/ion-rust/blob/a4b154cc0a5b5b661a45ac14d3719a501573d8f2/.github/workflows/rust.yml#L13-L28
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-2019]
 
     steps:
       - name: Git Checkout
@@ -35,10 +33,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --verbose --workspace -- --test-threads=1
-      # TODO: run rustfmt and enable check
-      # - name: Rustfmt Check
-      #   uses: actions-rs/cargo@v1
-      #   with:
-      #     command: fmt
-      #     args: --verbose -- --check
+          args: --verbose --workspace
+      - name: Rustfmt Check
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --verbose -- --check

--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@ and the API is subject to change._
 
 1. Clone the repository
    ```
-   git clone --recursive https://github.com/amzn/ion-cli.git
+   git clone https://github.com/amzn/ion-cli.git
    ```
-   (If you had already cloned it, but the `ion-c` directory is missing or empty, run `git submodule update --init --recursive`.)
 
 2. Step into the newly created directory
    ```
@@ -23,8 +22,6 @@ and the API is subject to change._
    cargo install --path .
    ```
    This will put a copy of the `ion` executable in `~/.cargo/bin`.
-
-   **If this step fails:** You're likely missing one of `ion-c`'s dependencies. Make sure you have `cmake`, `gcc`, `g++` and `clang` installed. On Debian-based Linux distributions, the only required dependencies are `cmake` and `clang`.
 
 5. Confirm that `~/.cargo/bin` is on your `$PATH`. `rustup` will probably take care of this for you.
 


### PR DESCRIPTION
*Issue #, if available:*
* related to #5 but was really fixed in #25 

*Description of changes:*

Another very minor CI change after seeing the `ion-c` dependency was removed (:tada:). Wanted address some of the old TODOs mentioned in previous PR.

* add Windows build after testing in fork
* enable parallel tests, run rustfmt in CI
* remove mention of C toolchain requirements from README

Had originally added `-- --test-threads=1` since tests were flakey when there was the `ion-c` dependency. Running locally and in CI showed this is no longer needed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
