### PR TITLE
Upgrades ion-rs, adds beta 'count' and 'primitive' commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -218,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "ion-rs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6217a27014fd5bbb14a22bd71fa16ec3eb9ec399a71201cb9f1ad6c7f05732e"
+checksum = "bcdb581b7c70b45d3bd3dcedb0c0717c8c88ce853b78bc2788e2d2cd7689c9dc"
 dependencies = [
  "arrayvec",
  "base64",
@@ -237,14 +246,15 @@ dependencies = [
 
 [[package]]
 name = "ion-schema"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1470ac8ee2d8ff3f31532168ab9c7206da64204a34bcb438318298ed30b0b5"
+checksum = "375e2c2a58a2abbea4659982a96f3efc132dad573ca02beaa8f37ad7e8eb58d1"
 dependencies = [
  "chrono",
  "ion-rs",
  "num-bigint",
  "num-traits",
+ "regex",
  "thiserror",
 ]
 
@@ -440,10 +450,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ keywords = ["format", "parse", "encode"]
 anyhow = "1.0"
 clap = "~2.27.0"
 colored = "2.0.0"
-ion-rs = "0.11.0"
+ion-rs = "0.12.0"
 memmap = "0.7.0"
 tempfile = "3.2.0"
-ion-schema = "0.3.0"
+ion-schema = "0.4.0"
 
 [dev-dependencies]
 rstest = "~0.10.0"

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,0 +1,52 @@
+use crate::commands::CommandConfig;
+use anyhow::{Context, Result};
+use clap::{App, Arg, ArgMatches};
+use ion_rs::*;
+use std::fs::File;
+use std::io::{stdin, BufReader, StdinLock};
+
+pub fn app() -> CommandConfig {
+    App::new("count")
+        .about("Prints the number of top-level values found in the input stream.")
+        .arg(
+            // All argv entries after the program name (argv[0])
+            // and any `clap`-managed options are considered input files.
+            Arg::with_name("input")
+                .index(1)
+                .multiple(true)
+                .help("Input file [default: STDIN]"),
+        )
+}
+
+pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
+    if let Some(input_file_iter) = matches.values_of("input") {
+        for input_file in input_file_iter {
+            let file = File::open(input_file)
+                .with_context(|| format!("Could not open file '{}'", input_file))?;
+            let mut reader = ReaderBuilder::new().build(file)?;
+            print_top_level_value_count(&mut reader)?;
+        }
+    } else {
+        let input: StdinLock = stdin().lock();
+        let buf_reader = BufReader::new(input);
+        let mut reader = ReaderBuilder::new().build(buf_reader)?;
+        print_top_level_value_count(&mut reader)?;
+    };
+
+    Ok(())
+}
+
+fn print_top_level_value_count(reader: &mut Reader) -> Result<()> {
+    let mut count: usize = 0;
+    loop {
+        let item = reader
+            .next()
+            .with_context(|| "could not count values in Ion stream")?;
+        if item == StreamItem::Nothing {
+            break;
+        }
+        count += 1;
+    }
+    println!("{}", count);
+    Ok(())
+}

--- a/src/bin/ion/commands/beta/inspect.rs
+++ b/src/bin/ion/commands/beta/inspect.rs
@@ -367,6 +367,11 @@ impl<'a> IonInspector<'a> {
                     self.inspect_level()?;
                     self.reader.step_out()?;
                     // Print the container's closing delimiter: }, ), or ]
+                    self.text_buffer.clear();
+                    self.text_buffer.push_str(&closing_delimiter_for(ion_type));
+                    if ion_type != IonType::SExpression {
+                        self.text_buffer.push_str(",");
+                    }
                     // FIXME: This should also print a trailing `,` if the parent context is
                     //        a list or struct. See this issue for details:
                     //        https://github.com/amzn/ion-cli/issues/17
@@ -376,7 +381,7 @@ impl<'a> IonInspector<'a> {
                         None,
                         &self.indentation_buffer,
                         "",
-                        &closing_delimiter_for(ion_type),
+                        &self.text_buffer,
                     )?;
                 }
                 _ => {}
@@ -509,9 +514,7 @@ impl<'a> IonInspector<'a> {
             to_hex(&mut self.hex_buffer, self.reader.raw_value_bytes().unwrap());
         }
 
-        const TYPE_DESCRIPTOR_SIZE: usize = 1;
-        let length =
-            TYPE_DESCRIPTOR_SIZE + self.reader.header_length() + self.reader.value_length();
+        let length = self.reader.header_length() + self.reader.value_length();
         output(
             self.output,
             Some(self.reader.header_offset()),

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -1,4 +1,6 @@
+pub mod count;
 pub mod inspect;
+pub mod primitive;
 pub mod schema;
 
 use crate::commands::{CommandConfig, CommandRunner};
@@ -10,12 +12,19 @@ use clap::{App, ArgMatches};
 
 // Creates a Vec of CLI configurations for all of the available built-in commands
 pub fn beta_subcommands() -> Vec<CommandConfig> {
-    vec![inspect::app(), schema::app()]
+    vec![
+        count::app(),
+        inspect::app(),
+        primitive::app(),
+        schema::app(),
+    ]
 }
 
 pub fn runner_for_beta_subcommand(command_name: &str) -> Option<CommandRunner> {
     let runner = match command_name {
+        "count" => count::run,
         "inspect" => inspect::run,
+        "primitive" => primitive::run,
         "schema" => schema::run,
         _ => return None,
     };

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -1,0 +1,74 @@
+use crate::commands::CommandConfig;
+use anyhow::{Context, Result};
+use clap::{App, Arg, ArgMatches};
+use ion_rs::binary::var_int::VarInt;
+use ion_rs::binary::var_uint::VarUInt;
+
+pub fn app() -> CommandConfig {
+    App::new("primitive")
+        .about("Prints the binary representation of an Ion encoding primitive.")
+        .arg(
+            Arg::with_name("type")
+                .short("t")
+                .required(true)
+                .takes_value(true)
+                .help("The Ion primitive encoding type. (Names are case insensitive.)")
+                .possible_values(&["VarInt", "varint", "VarUInt", "varuint"]),
+        )
+        .arg(
+            Arg::with_name("value")
+                .short("v")
+                .required(true)
+                .allow_hyphen_values(true)
+                .takes_value(true)
+                .help("The value to encode as the specified primitive."),
+        )
+}
+
+pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> anyhow::Result<()> {
+    let mut buffer = Vec::new();
+    let value_text = matches.value_of("value").unwrap();
+    match matches.value_of("type").unwrap() {
+        "varuint" | "VarUInt" => {
+            let value = integer_from_text(value_text)? as u64;
+            VarUInt::write_u64(&mut buffer, value).unwrap();
+        }
+        "varint" | "VarInt" => {
+            let value = integer_from_text(value_text)?;
+            VarInt::write_i64(&mut buffer, value).unwrap();
+        }
+        unsupported => {
+            unreachable!(
+                "clap did not reject unsupported primitive encoding {}",
+                unsupported
+            );
+        }
+    }
+    print!("hex: ");
+    for byte in buffer.iter() {
+        // We want the hex bytes to align with the binary bytes that will be printed on the next
+        // line. Print 6 spaces and a 2-byte hex representation of the byte.
+        print!("      {:0>2x} ", byte);
+    }
+    println!();
+    print!("bin: ");
+    for byte in buffer.iter() {
+        // Print the binary representation of each byte
+        print!("{:0>8b} ", byte);
+    }
+    println!();
+    Ok(())
+}
+
+fn integer_from_text(text: &str) -> Result<i64> {
+    if text.starts_with("0x") {
+        i64::from_str_radix(text, 16)
+            .with_context(|| format!("{} is not a valid hexidecimal integer value.", text))
+    } else if text.starts_with("0b") {
+        i64::from_str_radix(text, 2)
+            .with_context(|| format!("{} is not a valid binary integer value.", text))
+    } else {
+        text.parse::<i64>()
+            .with_context(|| format!("{} is not a valid decimal integer value.", text))
+    }
+}

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -1,12 +1,12 @@
 use anyhow::{Context, Result};
 use clap::{App, Arg, ArgMatches};
-use ion_rs::value::native_writer::NativeElementWriter;
-use ion_rs::{IonResult, TextWriterBuilder, Writer};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
+use ion_schema::external::ion_rs::value::native_writer::NativeElementWriter;
 use ion_schema::external::ion_rs::value::owned::OwnedElement;
 use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
 use ion_schema::external::ion_rs::value::writer::ElementWriter;
 use ion_schema::external::ion_rs::IonType;
+use ion_schema::external::ion_rs::{IonResult, TextWriterBuilder, Writer};
 use ion_schema::system::SchemaSystem;
 use std::fs;
 use std::path::Path;

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -63,8 +63,6 @@ pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
         }
     } else {
         let input: StdinLock = stdin().lock();
-        // TODO: This `BufReader` is only required because StdInLock doesn't yet implement
-        //       ToIonDataSource. It's probably unnecessary overhead.
         let buf_reader = BufReader::new(input);
         let mut reader = ReaderBuilder::new().build(buf_reader)?;
         write_all_in_format(&mut reader, &mut output, format)?;
@@ -108,7 +106,7 @@ fn write_all_values<W: Writer>(reader: &mut Reader, writer: &mut W) -> IonResult
     let mut annotations = vec![];
     loop {
         match reader.next()? {
-            StreamItem::Value(ion_type) => {
+            StreamItem::Value(ion_type) | StreamItem::Null(ion_type) => {
                 if reader.has_annotations() {
                     annotations.clear();
                     for annotation in reader.annotations() {
@@ -121,12 +119,26 @@ fn write_all_values<W: Writer>(reader: &mut Reader, writer: &mut W) -> IonResult
                     writer.set_field_name(reader.field_name()?);
                 }
 
+                if reader.is_null() {
+                    writer.write_null(ion_type)?;
+                    continue;
+                }
+
                 use IonType::*;
                 match ion_type {
-                    Null => unreachable!("StreamItem::Value(_) never contains a null"),
+                    Null => unreachable!("null values are handled prior to this match"),
                     Boolean => writer.write_bool(reader.read_bool()?)?,
                     Integer => writer.write_integer(&reader.read_integer()?)?,
-                    Float => writer.write_f64(reader.read_f64()?)?,
+                    Float => {
+                        let float64 = reader.read_f64()?;
+                        let float32 = float64 as f32;
+                        if float32 as f64 == float64 {
+                            // No data lost during cast; write it as an f32
+                            writer.write_f32(float32)?;
+                        } else {
+                            writer.write_f64(float64)?;
+                        }
+                    }
                     Decimal => writer.write_decimal(&reader.read_decimal()?)?,
                     Timestamp => writer.write_timestamp(&reader.read_timestamp()?)?,
                     Symbol => writer.write_symbol(reader.read_symbol()?.as_ref())?,
@@ -135,19 +147,18 @@ fn write_all_values<W: Writer>(reader: &mut Reader, writer: &mut W) -> IonResult
                     Blob => writer.write_blob(reader.read_blob()?)?,
                     List => {
                         reader.step_in()?;
-                        writer.step_in(IonType::List)?;
+                        writer.step_in(List)?;
                     }
                     SExpression => {
                         reader.step_in()?;
-                        writer.step_in(IonType::SExpression)?;
+                        writer.step_in(SExpression)?;
                     }
                     Struct => {
                         reader.step_in()?;
-                        writer.step_in(IonType::Struct)?;
+                        writer.step_in(Struct)?;
                     }
                 }
             }
-            StreamItem::Null(ion_type) => writer.write_null(ion_type)?,
             StreamItem::Nothing if reader.depth() > 0 => {
                 reader.step_out()?;
                 writer.step_out()?;

--- a/src/bin/ion/commands/dump.rs
+++ b/src/bin/ion/commands/dump.rs
@@ -3,7 +3,7 @@ use anyhow::{Context, Result};
 use clap::{App, Arg, ArgMatches};
 use ion_rs::*;
 use std::fs::File;
-use std::io::{stdin, stdout, BufReader, StdinLock, Write};
+use std::io::{stdin, stdout, StdinLock, Write};
 
 pub fn app() -> CommandConfig {
     App::new("dump")
@@ -63,8 +63,7 @@ pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
         }
     } else {
         let input: StdinLock = stdin().lock();
-        let buf_reader = BufReader::new(input);
-        let mut reader = ReaderBuilder::new().build(buf_reader)?;
+        let mut reader = ReaderBuilder::new().build(input)?;
         write_all_in_format(&mut reader, &mut output, format)?;
     }
 


### PR DESCRIPTION
* Upgrades dependency on `ion-rs` to v0.12.0
* Updates `ion-schema` to v0.4.0, which uses ion-rs v0.12.0
* Modifies the way encoding lengths are calculated following
  a change in the v0.12.0 binary reader API.
* Fixes issue #17; nested containers now have a trailing comma
  where necessary.
* Adds a `beta count` command that prints the number of top-level
  values in a given stream.
* Adds a `beta primitive` command that prints the decimal and
  hex representations of a value's primitive encoding
  (For example: the VarUInt encoding of 527.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
