### PR TITLE
Upgrades `clap` from 2.x to 4.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,12 +30,6 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "ansi_term"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ac7c30002a5accbf7e8987d0632fa6de155b7c3d39d0067317a391e00a2ef6"
 
 [[package]]
 name = "anyhow"
@@ -85,12 +90,6 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
-
-[[package]]
-name = "bitflags"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4efd02e230a02e18f92fc2735f44597385ed02ad8f831e7c1c1156ee5e1ab3a5"
 
 [[package]]
 name = "bitflags"
@@ -160,17 +159,25 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.27.1"
+version = "4.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8c532887f1a292d17de05ae858a8fe50a301e196f9ef0ddb7ccd0d1d00f180"
+checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
- "ansi_term",
  "atty",
- "bitflags 0.9.1",
+ "bitflags",
+ "clap_lex",
+ "once_cell",
  "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -285,6 +292,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +379,8 @@ dependencies = [
 [[package]]
 name = "ion-rs"
 version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c00eb850bb273098d0cf8595705a83bdc03f53d59e3fc05bb4338953370344"
 dependencies = [
  "arrayvec",
  "base64",
@@ -361,6 +388,7 @@ dependencies = [
  "bytes",
  "chrono",
  "delegate",
+ "hashlink",
  "nom",
  "num-bigint",
  "num-integer",
@@ -509,6 +537,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
+
+[[package]]
 name = "pest"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -605,7 +639,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags",
 ]
 
 [[package]]
@@ -694,9 +728,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
-version = "0.6.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -737,15 +771,6 @@ name = "termtree"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
-
-[[package]]
-name = "textwrap"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "thiserror"
@@ -797,10 +822,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wait-timeout"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["format", "parse", "encode"]
 
 [dependencies]
 anyhow = "1.0"
-clap = "~2.27.0"
+clap = { version = "4.0.17", features = ["cargo"] }
 colored = "2.0.0"
 ion-rs = "0.14.0"
 memmap = "0.7.0"

--- a/src/bin/ion/commands/beta/count.rs
+++ b/src/bin/ion/commands/beta/count.rs
@@ -1,25 +1,25 @@
-use crate::commands::CommandConfig;
 use anyhow::{Context, Result};
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_rs::*;
 use std::fs::File;
 use std::io::{stdin, BufReader, StdinLock};
 
-pub fn app() -> CommandConfig {
-    App::new("count")
+pub fn app() -> Command {
+    Command::new("count")
         .about("Prints the number of top-level values found in the input stream.")
         .arg(
             // All argv entries after the program name (argv[0])
             // and any `clap`-managed options are considered input files.
-            Arg::with_name("input")
+            Arg::new("input")
                 .index(1)
-                .multiple(true)
-                .help("Input file [default: STDIN]"),
+                .help("Input file [default: STDIN]")
+                .action(ArgAction::Append)
+                .trailing_var_arg(true),
         )
 }
 
-pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
-    if let Some(input_file_iter) = matches.values_of("input") {
+pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
+    if let Some(input_file_iter) = matches.get_many::<String>("input") {
         for input_file in input_file_iter {
             let file = File::open(input_file)
                 .with_context(|| format!("Could not open file '{}'", input_file))?;

--- a/src/bin/ion/commands/beta/mod.rs
+++ b/src/bin/ion/commands/beta/mod.rs
@@ -3,15 +3,15 @@ pub mod inspect;
 pub mod primitive;
 pub mod schema;
 
-use crate::commands::{CommandConfig, CommandRunner};
+use crate::commands::CommandRunner;
 use anyhow::Result;
-use clap::{App, ArgMatches};
+use clap::{ArgMatches, Command};
 
 // To add a beta subcommand, add your new command to the `beta_subcommands`
 // and `runner_for_beta_subcommands` functions.
 
 // Creates a Vec of CLI configurations for all of the available built-in commands
-pub fn beta_subcommands() -> Vec<CommandConfig> {
+pub fn beta_subcommands() -> Vec<Command> {
     vec![
         count::app(),
         inspect::app(),
@@ -32,14 +32,14 @@ pub fn runner_for_beta_subcommand(command_name: &str) -> Option<CommandRunner> {
 }
 
 // The functions below are used by the top-level `ion` command when `beta` is invoked.
-pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
+pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
     //     ^-- At this level of dispatch, this command will always be the text `beta`.
     // We want to evaluate the name of the subcommand that was invoked --v
-    let (command_name, command_args) = matches.subcommand();
+    let (command_name, command_args) = matches.subcommand().unwrap();
     if let Some(runner) = runner_for_beta_subcommand(command_name) {
         // If a runner is registered for the given command name, command_args is guaranteed to
         // be defined; we can safely unwrap it.
-        runner(command_name, command_args.unwrap())?;
+        runner(command_name, command_args)?;
     } else {
         let message = format!(
             "The requested beta command ('{}') is not supported and clap did not generate an error message.",
@@ -50,8 +50,8 @@ pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
     Ok(())
 }
 
-pub fn app() -> CommandConfig {
-    App::new("beta")
+pub fn app() -> Command {
+    Command::new("beta")
         .about(
             "The 'beta' command is a namespace for commands whose interfaces are not yet stable.",
         )

--- a/src/bin/ion/commands/beta/primitive.rs
+++ b/src/bin/ion/commands/beta/primitive.rs
@@ -1,34 +1,31 @@
-use crate::commands::CommandConfig;
 use anyhow::{Context, Result};
-use clap::{App, Arg, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 use ion_rs::binary::var_int::VarInt;
 use ion_rs::binary::var_uint::VarUInt;
 
-pub fn app() -> CommandConfig {
-    App::new("primitive")
+pub fn app() -> Command {
+    Command::new("primitive")
         .about("Prints the binary representation of an Ion encoding primitive.")
         .arg(
-            Arg::with_name("type")
-                .short("t")
+            Arg::new("type")
+                .short('t')
                 .required(true)
-                .takes_value(true)
                 .help("The Ion primitive encoding type. (Names are case insensitive.)")
-                .possible_values(&["VarInt", "varint", "VarUInt", "varuint"]),
+                .value_parser(["VarInt", "varint", "VarUInt", "varuint"]),
         )
         .arg(
-            Arg::with_name("value")
-                .short("v")
+            Arg::new("value")
+                .short('v')
                 .required(true)
                 .allow_hyphen_values(true)
-                .takes_value(true)
                 .help("The value to encode as the specified primitive."),
         )
 }
 
-pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> anyhow::Result<()> {
+pub fn run(_command_name: &str, matches: &ArgMatches) -> anyhow::Result<()> {
     let mut buffer = Vec::new();
-    let value_text = matches.value_of("value").unwrap();
-    match matches.value_of("type").unwrap() {
+    let value_text = matches.get_one::<String>("value").unwrap().as_str();
+    match matches.get_one::<String>("type").unwrap().as_str() {
         "varuint" | "VarUInt" => {
             let value = integer_from_text(value_text)? as u64;
             VarUInt::write_u64(&mut buffer, value).unwrap();

--- a/src/bin/ion/commands/beta/schema/mod.rs
+++ b/src/bin/ion/commands/beta/schema/mod.rs
@@ -1,15 +1,15 @@
 pub mod load;
 pub mod validate;
 
-use crate::commands::{CommandConfig, CommandRunner};
+use crate::commands::CommandRunner;
 use anyhow::Result;
-use clap::{App, ArgMatches};
+use clap::{ArgMatches, Command};
 
 // To add a schema subcommand, add your new command to the `schema_subcommands`
 // and `runner_for_schema_subcommands` functions.
 
 // Creates a Vec of CLI configurations for all of the available built-in subcommands for schema
-pub fn schema_subcommands() -> Vec<CommandConfig> {
+pub fn schema_subcommands() -> Vec<Command> {
     vec![load::app(), validate::app()]
 }
 
@@ -23,13 +23,13 @@ pub fn runner_for_schema_subcommand(command_name: &str) -> Option<CommandRunner>
 }
 
 // The functions below are used by the `beta` subcommand when `schema` is invoked.
-pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
+pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
     // We want to evaluate the name of the subcommand that was invoked
-    let (command_name, command_args) = matches.subcommand();
+    let (command_name, command_args) = matches.subcommand().unwrap();
     if let Some(runner) = runner_for_schema_subcommand(command_name) {
         // If a runner is registered for the given command name, command_args is guaranteed to
         // be defined; we can safely unwrap it.
-        runner(command_name, command_args.unwrap())?;
+        runner(command_name, command_args)?;
     } else {
         let message = format!(
             "The requested schema command ('{}') is not supported and clap did not generate an error message.",
@@ -40,8 +40,8 @@ pub fn run(_command_name: &str, matches: &ArgMatches<'static>) -> Result<()> {
     Ok(())
 }
 
-pub fn app() -> CommandConfig {
-    App::new("schema")
+pub fn app() -> Command {
+    Command::new("schema")
         .about(
             "The 'schema' command is a namespace for commands that are related to schema sandbox",
         )

--- a/src/bin/ion/commands/mod.rs
+++ b/src/bin/ion/commands/mod.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
-use clap::{App, ArgMatches};
+use clap::{ArgMatches, Command};
 
 pub mod beta;
 pub mod dump;
 
-pub type CommandConfig = App<'static, 'static>;
-pub type CommandRunner = fn(&str, &ArgMatches<'static>) -> Result<()>;
+pub type CommandRunner = fn(&str, &ArgMatches) -> Result<()>;
 
 // Creates a Vec of CLI configurations for all of the available built-in commands
-pub fn built_in_commands() -> Vec<CommandConfig> {
+pub fn built_in_commands() -> Vec<Command> {
     vec![dump::app(), beta::app()]
 }
 

--- a/src/bin/ion/main.rs
+++ b/src/bin/ion/main.rs
@@ -2,28 +2,27 @@ mod commands;
 
 use crate::commands::{built_in_commands, runner_for_built_in_command};
 use anyhow::Result;
-use clap::{crate_authors, crate_version, App, AppSettings};
+use clap::{crate_authors, crate_version, Command};
 
 const PROGRAM_NAME: &str = "ion";
 
 fn main() -> Result<()> {
-    let mut app = App::new(PROGRAM_NAME)
+    let mut app = Command::new(PROGRAM_NAME)
         .version(crate_version!())
         .author(crate_authors!())
-        .setting(AppSettings::SubcommandRequiredElseHelp)
-        .setting(AppSettings::TrailingVarArg);
+        .subcommand_required(true);
 
     for command in built_in_commands() {
         app = app.subcommand(command);
     }
 
     let args = app.get_matches();
-    let (command_name, command_args) = args.subcommand();
+    let (command_name, command_args) = args.subcommand().unwrap();
 
     if let Some(runner) = runner_for_built_in_command(command_name) {
         // If a runner is registered for the given command name, command_args is guaranteed to
         // be defined.
-        runner(command_name, command_args.unwrap())?;
+        runner(command_name, command_args)?;
     } else {
         let message = format!(
             "The requested command ('{}') is not supported and clap did not generate an error message.",


### PR DESCRIPTION
The `ion-cli` now uses the latest major version of `clap`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
