### PR TITLE
Updates `ion-schema-rust` to `v0.6.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,30 +350,11 @@ dependencies = [
  "assert_cmd",
  "clap",
  "colored",
- "ion-rs 0.14.0",
+ "ion-rs",
  "ion-schema",
  "memmap",
  "rstest",
  "tempfile",
-]
-
-[[package]]
-name = "ion-rs"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcdb581b7c70b45d3bd3dcedb0c0717c8c88ce853b78bc2788e2d2cd7689c9dc"
-dependencies = [
- "arrayvec",
- "base64",
- "bigdecimal",
- "bytes",
- "chrono",
- "delegate",
- "nom",
- "num-bigint",
- "num-integer",
- "num-traits",
- "thiserror",
 ]
 
 [[package]]
@@ -399,12 +380,12 @@ dependencies = [
 
 [[package]]
 name = "ion-schema"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375e2c2a58a2abbea4659982a96f3efc132dad573ca02beaa8f37ad7e8eb58d1"
+checksum = "4b81d377f1df2b98a3ce41d7154d74bfc1ac13b9e0a78c752d377a86f05477cb"
 dependencies = [
  "chrono",
- "ion-rs 0.12.0",
+ "ion-rs",
  "num-bigint",
  "num-traits",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ colored = "2.0.0"
 ion-rs = "0.14.0"
 memmap = "0.7.0"
 tempfile = "3.2.0"
-ion-schema = "0.4.0"
+ion-schema = "0.6.0"
 
 [dev-dependencies]
 rstest = "~0.10.0"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,24 @@ ion beta inspect --skip-bytes 30 --limit-bytes 2 my_file.10n
           |           |                          |  }
 ```
 
+### Schema subcommands
+All the subcommand to load or validate schema are under the `beta schema` subcommand.
+
+To load a schema:
+```bash
+ion beta schema load --directory <DIRECTORY> --schema <SCHEMA_FILE> 
+```
+
+To validate an ion value against a schema type:
+```bash
+ion beta schema validate --directory <DIRECTORY> --schema <SCHEMA_FILE> --input <INPUT_FILE> --type <TYPE>
+```
+
+For more information on how to use the schema subcommands using CLI, run the following command:
+```bash
+ion beta schema help  
+```
+
 ## Installation
 
 ### via `brew`

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
+use ion_rs::IonWriter;
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
 use ion_schema::external::ion_rs::value::native_writer::NativeElementWriter;
 use ion_schema::external::ion_rs::value::owned::Element;
@@ -8,7 +9,6 @@ use ion_schema::external::ion_rs::value::writer::ElementWriter;
 use ion_schema::external::ion_rs::IonType;
 use ion_schema::external::ion_rs::{IonResult, TextWriterBuilder};
 use ion_schema::system::SchemaSystem;
-use ion_rs::IonWriter;
 use std::fs;
 use std::path::Path;
 use std::str::from_utf8;

--- a/src/bin/ion/commands/beta/schema/validate.rs
+++ b/src/bin/ion/commands/beta/schema/validate.rs
@@ -2,12 +2,13 @@ use anyhow::{Context, Result};
 use clap::{Arg, ArgAction, ArgMatches, Command};
 use ion_schema::authority::{DocumentAuthority, FileSystemDocumentAuthority};
 use ion_schema::external::ion_rs::value::native_writer::NativeElementWriter;
-use ion_schema::external::ion_rs::value::owned::OwnedElement;
+use ion_schema::external::ion_rs::value::owned::Element;
 use ion_schema::external::ion_rs::value::reader::{element_reader, ElementReader};
 use ion_schema::external::ion_rs::value::writer::ElementWriter;
 use ion_schema::external::ion_rs::IonType;
-use ion_schema::external::ion_rs::{IonResult, TextWriterBuilder, Writer};
+use ion_schema::external::ion_rs::{IonResult, TextWriterBuilder};
 use ion_schema::system::SchemaSystem;
+use ion_rs::IonWriter;
 use std::fs;
 use std::path::Path;
 use std::str::from_utf8;
@@ -73,7 +74,7 @@ pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
     // Extract Ion value provided by user
     let input_file = matches.get_one::<String>("input").unwrap();
     let value = fs::read(input_file).with_context(|| format!("Could not open '{}'", schema_id))?;
-    let owned_elements: Vec<OwnedElement> = element_reader()
+    let owned_elements: Vec<Element> = element_reader()
         .read_all(&value)
         .with_context(|| format!("Could not parse Ion file: '{}'", schema_id))?;
 
@@ -129,9 +130,9 @@ pub fn run(_command_name: &str, matches: &ArgMatches) -> Result<()> {
     Ok(())
 }
 
-// TODO: this will be provided by OwnedElement's implementation of `Display` in a future
+// TODO: this will be provided by Element's implementation of `Display` in a future
 //       release of ion-rs.
-fn element_to_string(element: &OwnedElement) -> IonResult<String> {
+fn element_to_string(element: &Element) -> IonResult<String> {
     let mut buffer = Vec::new();
     let text_writer = TextWriterBuilder::new().build(std::io::Cursor::new(&mut buffer))?;
     let mut element_writer = NativeElementWriter::new(text_writer);


### PR DESCRIPTION
*Description of changes:*
This PR works on updating `ion-schema-rust` to latest version `0.6.0` and adds `schema` sub command guidelines in README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
